### PR TITLE
Added 'explorerExclude.showPicker' configuration option, which when f…

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,10 @@ Select Filter Options you wish to Hide Files & Folders
 
 ![picker](https://explorer-exclude.s3.amazonaws.com/picker.gif?v=1.2.0)
 
+You can disable the filter option popup, and by default only allow the selected item to be hidden, by adding this setting in VSCode:
+
+`"explorerExclude.showPicker": false`
+
 #### Managing Hidden Files & Folders
 
 New `HIDDEN ITEMS` Explorer Pane to Manage Hidden Files:

--- a/util.js
+++ b/util.js
@@ -380,41 +380,51 @@ function vscExclude(uri, callback) {
             let selections;
             let options = [];
 
-            Object.keys(_meta).forEach(key => {
-                let regex = undefined;
-                switch (key) {
-                    case 'path':
-                        break;
-                    case 'ext':
-                        regex = _meta[key] ? `**/*${_meta[key]}` : undefined;
-                        break;
-                    case 'base':
-                        regex = _meta[key];
-                        break;
-                    case 'dir':
-                        regex = _meta[key] ? `${_meta[key] + '/'}*.*` : undefined;
-                        break;
-                }
-                if (regex) {
-                    options.push(regex);
-                }
-            });
+            const _showPicker = vscode.workspace.getConfiguration(null, null).get('explorerExclude.showPicker');
+            if (typeof _showPicker == 'undefined')
+                _showPicker = true;
 
-            if (_meta['dir'] && _meta['ext']) {
-                options.push(`${_meta['dir']}/*${_meta['ext']}`);
-            }
-            else if (_meta['ext']) {
-                options.push(`*${_meta['ext']}`);
-            }
+            if (_showPicker) {
+                Object.keys(_meta).forEach(key => {
+                    let regex = undefined;
+                    switch (key) {
+                        case 'path':
+                            break;
+                        case 'ext':
+                                regex = _meta[key] ? `**/*${_meta[key]}` : undefined;
+                            break;
+                        case 'base':
+                            regex = _meta[key];
+                            break;
+                        case 'dir':
+                            if (_showPicker)
+                                regex = _meta[key] ? `${_meta[key] + '/'}*.*` : undefined;
+                            break;
+                    }
+                    if (regex) {
+                        options.push(regex);
+                    }
+                });
 
-            if (_meta['base']) {
-                options.push(`**/${_meta['base']}`);
-                if (_meta['dir']) {
-                    options.push(`${_meta['dir']}/${_meta['base']}`);
+                if (_meta['dir'] && _meta['ext']) {
+                    options.push(`${_meta['dir']}/*${_meta['ext']}`);
                 }
-            }
+                else if (_meta['ext']) {
+                    options.push(`*${_meta['ext']}`);
+                }
 
-            selections = yield showPicker(options.reverse());
+                if (_meta['base']) {
+                    options.push(`**/${_meta['base']}`);
+                    if (_meta['dir']) {
+                        options.push(`${_meta['dir']}/${_meta['base']}`);
+                    }
+                }
+
+                selections = yield showPicker(options.reverse());
+            } else {
+                if (_meta['base'])
+                    selections = [_meta['base']];
+            }
 
             if (selections && selections.length > 0) {
                 const config = vscode.workspace.getConfiguration('files', null);


### PR DESCRIPTION
…alse will NOT show the file picker, but only hide the currently selected item

#### What's this PR do?

It adds a check in util.js for a configuration/setting option: "explorerExclude.showPicker".
If this is true (or undefined), the extension works as is... if it is false it will NOT show any file picker/choose after clicking 'Add to hidden items...', but will only hide the already selected item.

#### Where should the reviewer start?

util.js line 383

#### How should this be manually tested?

Add a vscode setting called: "explorerExclude.showPicker": false and then try to hide any selected item. Set the value to true and confirm the default behavior works.


#### Any background context you want to provide?

Sure - I was glad to find an extension that would work within Workspaces, as the 'Make Hidden' extension doesn't. Upon using this, I simply want to hide one item at a time in the explorer (main use case), quickly, without being prompted every time, so I thought making this a configuration option made sense. 

#### Definition of Done:

- [ x] You have actually run this locally and can verify it works
- [ ] You have verified that `npm test` passes without issue
- [ x] You have updated the README file (if appropriate)
