### PR TITLE
Fix squiggle in a user's settings json file

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
         "title": "%package.pane%",
         "properties": {
           "explorerExclude.backup": {
-						"type": "object",
+						"type": ["object","null"],
 						"default": {},
 						"description": "Resource configuration: Configure files using glob patterns to have an empty last line always",
 						"scope": "resource"


### PR DESCRIPTION
I looked at: https://code.visualstudio.com/api/references/contribution-points#contributes.configuration and found the reason for the error squiggle was simply fixed. All you needed to do is allow for the type to be null here. I've already tested it on my computer by changing it on the extension (in %USERPROFILE%\.vscode\extensions\redvanworkshop.explorer-exclude-vscode-extension-1.2.0 since I'm currently using Windows) and the error squiggle immediately disappeared. No need to make it an empty object or anything.

#### What's this PR do?

Fixes the error squiggle in a user's settings file (workspace.code-workspace or settings.json) by allowing the type to be null.

#### Where should the reviewer start?

(https://code.visualstudio.com/api/references/contribution-points#contributes.configuration)

#### How should this be manually tested?

Change it in the extension (which I found here): https://code.visualstudio.com/docs/editor/extension-marketplace#_where-are-extensions-installed

#### Any background context you want to provide?

I was really annoyed at that squiggle and after trying to mess with JSON schemas for a while, decided to see if I could fix it here. I eventually searched for something like "vscode settings null" and found several configuration options have null as a default. I then searched "vscode extension configuration" and figured out the issue.

#### What are the relevant github issue?

While it was closed, I found a quick fix for the issue. (https://github.com/redvanworkshop/explorer-exclude-vscode-extension/issues/24)


#### What gif best describes this PR or how it makes you feel?

![giphy](https://user-images.githubusercontent.com/3577205/151930606-187f03f4-2308-4725-b3dc-5636ca893516.gif)
 (I was messing with schemas for hours, on and off, and was having some OCD-like tendencies about the squiggle).

#### Definition of Done:

- [x] You have actually run this locally and can verify it works
- [ ] You have verified that `npm test` passes without issue (have no idea where this is, couldn't find it after seeing it's supposed to be in, I think, the package.json under the "script" section)
