### PR TITLE
fix error when active text editor does not belong to any of the workspace folders of a multiroot workspace

### DIFF
--- a/extension/util.js
+++ b/extension/util.js
@@ -75,6 +75,12 @@ const getWorkspace = (context) => {
           const relative = path.relative(wsFolder.uri.fsPath, vscode.window.activeTextEditor.document.uri.path)
           return relative && !relative.startsWith('..') && !path.isAbsolute(relative)
         })
+
+        // The file that is active does not belong to any of the workspace folders, so let's use the first workspace
+        if (!root) {
+          root = vscode.workspace.workspaceFolders[0]
+        }
+        
         workspace = root && root.uri ? root.uri.fsPath : null
       } else {
         // No file was open, so just grab the first available workspace


### PR DESCRIPTION
Overview
---

When you have a multiroot workspace and the active text editor is something that does not belong to any of the workspace folders (like when you open a file directly from your desktop) you get an error `Explorer Exclude: Workspace Folder Not Found. Open Folder or Workspace and try again.`

Reviewer
---

> Where should the reviewer start? How to Test? Background Context? etc ( required )

1. Open a vscode window with a multiroot workspace
2. Open the file from your desktop (like a markdown file)
3. Reload the window
4. Wait until vscode finish to startup and **you should not see any error now**.

Checklist
---

> I have tested each of the following, and they work as expected: ( required )

- [x] Meets [Contributing Guide](https://github.com/sfccdevops/explorer-exclude-vscode-extension/blob/develop/.github/CONTRIBUTING.md) Requirements
- [x] Pulled in the Latest Code from the `develop` branch
- [x] Works on a Desktop / Laptop Device

Documentation
---

> Screenshots, Attachments, Linked GitHub Issues, etc ( optional )

fixes #37 

#### What GIF best describes this PR or how it makes you feel?

![great](https://user-images.githubusercontent.com/4262050/182914238-5055f75e-2821-4703-ab26-4ca7657f142c.gif)

