### PR TITLE
Add an option to show hidden items from VS Code QuickPick quickly 

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,36 +1,36 @@
 module.exports = {
-    root: true,
-    parserOptions: {
-      parser: 'babel-eslint',
-      ecmaVersion: 8,
-    },
-    env: {
-      es6: true,
-      node: true,
-      browser: true,
-      jest: true,
-    },
-    plugins: ['prettier'],
-    extends: ['eslint:recommended', 'prettier'],
-    rules: {
-      'prettier/prettier': [
-        'error',
-        {
-          singleQuote: true,
-          bracketSpacing: true,
-          semi: false,
-          printWidth: 500,
-        },
-      ],
-      'no-empty': [
-        'error',
-        {
-          allowEmptyCatch: true,
-        },
-      ],
-      'no-console': 0,
-      'no-control-regex': 0,
-      'no-useless-escape': 0,
-    },
-    globals: {},
-  }
+  root: true,
+  parserOptions: {
+    parser: 'babel-eslint',
+    ecmaVersion: 8,
+  },
+  env: {
+    es6: true,
+    node: true,
+    browser: true,
+    jest: true,
+  },
+  plugins: ['prettier'],
+  extends: ['eslint:recommended', 'prettier'],
+  rules: {
+    'prettier/prettier': [
+      'error',
+      {
+        singleQuote: true,
+        bracketSpacing: true,
+        semi: false,
+        printWidth: 500,
+      },
+    ],
+    'no-empty': [
+      'error',
+      {
+        allowEmptyCatch: true,
+      },
+    ],
+    'no-console': 0,
+    'no-control-regex': 0,
+    'no-useless-escape': 0,
+  },
+  globals: {},
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@ Change Log
 
 > Here's our record of all notable changes made to to this project
 
+V1.3.3
+---
+
+* Add explorer-exclude.showSelected command that opens up a QuickPick window with all the excluded items and allows you to quickly filter and select which item you want to be visible in the explorer.
+
 v1.3.2
 ---
 

--- a/extension.code-workspace
+++ b/extension.code-workspace
@@ -11,6 +11,7 @@
 			"srggrs",
 			"viewpane",
 			"vsix"
-		]
+        ],
+        "nuxt.isNuxtApp": false
 	}
 }

--- a/extension/index.js
+++ b/extension/index.js
@@ -123,6 +123,32 @@ function activate(context) {
     })
   })
 
+  /*
+        This command will show a quick pick of all the excluded items
+        and allow the user to select which ones they want to show.
+    */
+  const showSelected = vscode.commands.registerCommand('explorer-exclude.showSelected', async () => {
+    util.logger('Toggle All Selected Excludes: Visible', 'debug')
+    const excludedItems = util.getExcludes()
+    const selectedExcluded = await vscode.window.showQuickPick(excludedItems, {
+      placeHolder: 'Select Excluded Files/Folders to Show',
+      canPickMany: true,
+    })
+    /*
+        First we need to enable all the excludes (Make everything hidden)
+        */
+    util.enableAll(function () {
+      /*
+        Then we need to set the selected excludes to visible
+        */
+      util.setExcludeVisible(selectedExcluded, function () {})
+
+      setTimeout(function () {
+        pane.update(util.getExcludes())
+      }, timeout * 10)
+    })
+  })
+
   // Set Initial State of Extension
   vscode.commands.executeCommand('setContext', 'explorer-exclude.enabled', true)
   vscode.commands.executeCommand('setContext', 'explorer-exclude.hasLoaded', true)
@@ -143,6 +169,8 @@ function activate(context) {
   context.subscriptions.push(toggle)
   context.subscriptions.push(toggleAllOff)
   context.subscriptions.push(toggleAllOn)
+
+  context.subscriptions.push(showSelected)
 }
 
 /**

--- a/extension/util.js
+++ b/extension/util.js
@@ -522,6 +522,30 @@ function toggleExclude(key, callback) {
   }
 }
 
+/**
+ * Set Visibility of Excluded Pattern
+ * This function get the exclude items keys and make only them visible
+ * @param {string} keysToShow
+ * @param {function} callback
+ */
+function setExcludeVisible(keysToShow, callback) {
+  if (!keysToShow) {
+    return false
+  }
+
+  const excludes = vscode.workspace.getConfiguration().get('files.exclude', vscode.ConfigurationTarget.Workspace) || {}
+
+  for (let key in keysToShow) {
+    key = keysToShow[key].split('|')[0]
+    // Set visability status
+    if (key && Object.prototype.hasOwnProperty.call(excludes, key)) {
+      logger(`Set: OFF | ${key}`, 'debug')
+      excludes[key] = false
+      updateConfig(excludes, callback)
+    }
+  }
+}
+
 module.exports = {
   deleteExclude,
   disableAll,
@@ -535,4 +559,5 @@ module.exports = {
   saveContext,
   toggleAll,
   toggleExclude,
+  setExcludeVisible,
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "explorer-exclude",
     "displayName": "Explorer Exclude",
-    "version": "1.3.2",
+    "version": "1.3.3",
     "description": "Explorer Exclude lets you easily Hide Files & Folders with Dynamic Filter Options.  Add a New 'Hidden Items' Explorer Pane for you to Manage and Quickly Toggle Visibility of Hidden Items.",
     "license": "MIT",
     "publisher": "PeterSchmalfeldt",
@@ -44,6 +44,10 @@
             "name": "Peter Schmalfeldt",
             "email": "me@peterschmalfeldt.com",
             "url": "https://peterschmalfeldt.com"
+        },
+        {
+            "name": "Asaf Mazuz",
+            "url": "https://github.com/AsafMazuz1"
         }
     ],
     "activationEvents": [

--- a/package.json
+++ b/package.json
@@ -1,244 +1,248 @@
 {
-  "name": "explorer-exclude",
-  "displayName": "Explorer Exclude",
-  "version": "1.3.2",
-  "description": "Explorer Exclude lets you easily Hide Files & Folders with Dynamic Filter Options.  Add a New 'Hidden Items' Explorer Pane for you to Manage and Quickly Toggle Visibility of Hidden Items.",
-  "license": "MIT",
-  "publisher": "PeterSchmalfeldt",
-  "categories": [
-    "Other"
-  ],
-  "main": "extension/index.js",
-  "icon": "extension/resources/icon.png",
-  "galleryBanner": {
-    "color": "#1c1c1c",
-    "theme": "dark"
-  },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/sfccdevops/explorer-exclude-vscode-extension"
-  },
-  "bugs": {
-    "url": "https://github.com/sfccdevops/explorer-exclude-vscode-extension/issues"
-  },
-  "engines": {
-    "vscode": "^1.60.0",
-    "node": "^14.19.0"
-  },
-  "keywords": [
-    "context-menu",
-    "exclude",
-    "explorer",
-    "files",
-    "folders",
-    "hidden",
-    "hide",
-    "ignore",
-    "pane",
-    "show",
-    "toggle",
-    "workspace"
-  ],
-  "contributors": [
-    {
-      "name": "Peter Schmalfeldt",
-      "email": "me@peterschmalfeldt.com",
-      "url": "https://peterschmalfeldt.com"
-    }
-  ],
-  "activationEvents": [
-    "onCommand:explorer-exclude.disableAll",
-    "onCommand:explorer-exclude.enableAll",
-    "onCommand:explorer-exclude.enabled",
-    "onCommand:explorer-exclude.exclude",
-    "onCommand:explorer-exclude.hasLoaded",
-    "onCommand:explorer-exclude.missingWorkspace",
-    "onCommand:explorer-exclude.remove",
-    "onCommand:explorer-exclude.reset",
-    "onCommand:explorer-exclude.toggle",
-    "onCommand:explorer-exclude.toggleAllOff",
-    "onCommand:explorer-exclude.toggleAllOn",
-    "onStartupFinished",
-    "onView:extension"
-  ],
-  "contributes": {
-    "configuration": [
-      {
-        "title": "%extension.title%",
-        "properties": {
-          "explorerExclude.backup": {
-            "order": 1,
-            "type": [
-              "object",
-              "null"
-            ],
-            "default": {},
-            "description": "%config.properties.backup%",
-            "scope": "window"
-          },
-          "explorerExclude.showPicker": {
-            "order": 2,
-            "type": "boolean",
-            "default": true,
-            "description": "%config.properties.showPicker%",
-            "scope": "window"
-          }
-        }
-      }
+    "name": "explorer-exclude",
+    "displayName": "Explorer Exclude",
+    "version": "1.3.2",
+    "description": "Explorer Exclude lets you easily Hide Files & Folders with Dynamic Filter Options.  Add a New 'Hidden Items' Explorer Pane for you to Manage and Quickly Toggle Visibility of Hidden Items.",
+    "license": "MIT",
+    "publisher": "PeterSchmalfeldt",
+    "categories": [
+        "Other"
     ],
-    "views": {
-      "explorer": [
-        {
-          "id": "explorerExclude.pane.items",
-          "name": "%package.pane%"
-        }
-      ]
+    "main": "extension/index.js",
+    "icon": "extension/resources/icon.png",
+    "galleryBanner": {
+        "color": "#1c1c1c",
+        "theme": "dark"
     },
-    "viewsWelcome": [
-      {
-        "view": "explorerExclude.pane.items",
-        "contents": "%package.loading%",
-        "when": "!explorer-exclude.missingWorkspace && !explorer-exclude.hasLoaded"
-      },
-      {
-        "view": "explorerExclude.pane.items",
-        "contents": "%debug.logger.missingWorkspace%",
-        "when": "explorer-exclude.missingWorkspace"
-      }
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/sfccdevops/explorer-exclude-vscode-extension"
+    },
+    "bugs": {
+        "url": "https://github.com/sfccdevops/explorer-exclude-vscode-extension/issues"
+    },
+    "engines": {
+        "vscode": "^1.60.0",
+        "node": "^14.19.0"
+    },
+    "keywords": [
+        "context-menu",
+        "exclude",
+        "explorer",
+        "files",
+        "folders",
+        "hidden",
+        "hide",
+        "ignore",
+        "pane",
+        "show",
+        "toggle",
+        "workspace"
     ],
-    "commands": [
-      {
-        "command": "explorer-exclude.exclude",
-        "title": "%package.exclude%"
-      },
-      {
-        "command": "explorer-exclude.remove",
-        "title": "%package.remove%"
-      },
-      {
-        "command": "explorer-exclude.toggle",
-        "title": "%package.toggle%"
-      },
-      {
-        "command": "explorer-exclude.toggleAllOn",
-        "title": "%package.toggle%",
-        "category": "ExplorerExclude",
-        "icon": {
-          "dark": "extension/resources/dark/toggle-on.svg",
-          "light": "extension/resources/light/toggle-on.svg"
+    "contributors": [
+        {
+            "name": "Peter Schmalfeldt",
+            "email": "me@peterschmalfeldt.com",
+            "url": "https://peterschmalfeldt.com"
         }
-      },
-      {
-        "command": "explorer-exclude.toggleAllOff",
-        "title": "%package.toggle%",
-        "category": "ExplorerExclude",
-        "icon": {
-          "dark": "extension/resources/dark/toggle-off.svg",
-          "light": "extension/resources/light/toggle-off.svg"
-        }
-      },
-      {
-        "command": "explorer-exclude.disableAll",
-        "title": "%package.disableAll%",
-        "category": "ExplorerExclude",
-        "icon": {
-          "dark": "extension/resources/dark/unchecked.svg",
-          "light": "extension/resources/light/unchecked.svg"
-        }
-      },
-      {
-        "command": "explorer-exclude.enableAll",
-        "title": "%package.enableAll%",
-        "category": "ExplorerExclude",
-        "icon": {
-          "dark": "extension/resources/dark/checked.svg",
-          "light": "extension/resources/light/checked.svg"
-        }
-      },
-      {
-        "command": "explorer-exclude.reset",
-        "title": "%package.reset%",
-        "category": "ExplorerExclude",
-        "icon": {
-          "dark": "extension/resources/dark/reset.svg",
-          "light": "extension/resources/light/reset.svg"
-        }
-      },
-      {
-        "command": "explorer-exclude.openSettings",
-        "title": "%command.openSettings.title%",
-        "category": "ExplorerExclude",
-        "icon": {
-          "dark": "extension/resources/dark/settings.svg",
-          "light": "extension/resources/light/settings.svg"
-        }
-      }
     ],
-    "menus": {
-      "explorer/context": [
-        {
-          "command": "explorer-exclude.exclude",
-          "group": "explorer-exclude@1",
-          "when": "explorer-exclude.hasLoaded && !explorer-exclude.missingWorkspace && activeViewlet == 'workbench.view.explorer'"
+    "activationEvents": [
+        "onCommand:explorer-exclude.disableAll",
+        "onCommand:explorer-exclude.enableAll",
+        "onCommand:explorer-exclude.enabled",
+        "onCommand:explorer-exclude.exclude",
+        "onCommand:explorer-exclude.hasLoaded",
+        "onCommand:explorer-exclude.missingWorkspace",
+        "onCommand:explorer-exclude.remove",
+        "onCommand:explorer-exclude.reset",
+        "onCommand:explorer-exclude.toggle",
+        "onCommand:explorer-exclude.toggleAllOff",
+        "onCommand:explorer-exclude.toggleAllOn",
+        "onStartupFinished",
+        "onView:extension"
+    ],
+    "contributes": {
+        "configuration": [
+            {
+                "title": "%extension.title%",
+                "properties": {
+                    "explorerExclude.backup": {
+                        "order": 1,
+                        "type": [
+                            "object",
+                            "null"
+                        ],
+                        "default": {},
+                        "description": "%config.properties.backup%",
+                        "scope": "window"
+                    },
+                    "explorerExclude.showPicker": {
+                        "order": 2,
+                        "type": "boolean",
+                        "default": true,
+                        "description": "%config.properties.showPicker%",
+                        "scope": "window"
+                    }
+                }
+            }
+        ],
+        "views": {
+            "explorer": [
+                {
+                    "id": "explorerExclude.pane.items",
+                    "name": "%package.pane%"
+                }
+            ]
+        },
+        "viewsWelcome": [
+            {
+                "view": "explorerExclude.pane.items",
+                "contents": "%package.loading%",
+                "when": "!explorer-exclude.missingWorkspace && !explorer-exclude.hasLoaded"
+            },
+            {
+                "view": "explorerExclude.pane.items",
+                "contents": "%debug.logger.missingWorkspace%",
+                "when": "explorer-exclude.missingWorkspace"
+            }
+        ],
+        "commands": [
+            {
+                "command": "explorer-exclude.showSelected",
+                "title": "%package.select%"
+            },
+            {
+                "command": "explorer-exclude.exclude",
+                "title": "%package.exclude%"
+            },
+            {
+                "command": "explorer-exclude.remove",
+                "title": "%package.remove%"
+            },
+            {
+                "command": "explorer-exclude.toggle",
+                "title": "%package.toggle%"
+            },
+            {
+                "command": "explorer-exclude.toggleAllOn",
+                "title": "%package.toggle%",
+                "category": "ExplorerExclude",
+                "icon": {
+                    "dark": "extension/resources/dark/toggle-on.svg",
+                    "light": "extension/resources/light/toggle-on.svg"
+                }
+            },
+            {
+                "command": "explorer-exclude.toggleAllOff",
+                "title": "%package.toggle%",
+                "category": "ExplorerExclude",
+                "icon": {
+                    "dark": "extension/resources/dark/toggle-off.svg",
+                    "light": "extension/resources/light/toggle-off.svg"
+                }
+            },
+            {
+                "command": "explorer-exclude.disableAll",
+                "title": "%package.disableAll%",
+                "category": "ExplorerExclude",
+                "icon": {
+                    "dark": "extension/resources/dark/unchecked.svg",
+                    "light": "extension/resources/light/unchecked.svg"
+                }
+            },
+            {
+                "command": "explorer-exclude.enableAll",
+                "title": "%package.enableAll%",
+                "category": "ExplorerExclude",
+                "icon": {
+                    "dark": "extension/resources/dark/checked.svg",
+                    "light": "extension/resources/light/checked.svg"
+                }
+            },
+            {
+                "command": "explorer-exclude.reset",
+                "title": "%package.reset%",
+                "category": "ExplorerExclude",
+                "icon": {
+                    "dark": "extension/resources/dark/reset.svg",
+                    "light": "extension/resources/light/reset.svg"
+                }
+            },
+            {
+                "command": "explorer-exclude.openSettings",
+                "title": "%command.openSettings.title%",
+                "category": "ExplorerExclude",
+                "icon": {
+                    "dark": "extension/resources/dark/settings.svg",
+                    "light": "extension/resources/light/settings.svg"
+                }
+            }
+        ],
+        "menus": {
+            "explorer/context": [
+                {
+                    "command": "explorer-exclude.exclude",
+                    "group": "explorer-exclude@1",
+                    "when": "explorer-exclude.hasLoaded && !explorer-exclude.missingWorkspace && activeViewlet == 'workbench.view.explorer'"
+                }
+            ],
+            "view/item/context": [
+                {
+                    "command": "explorer-exclude.remove",
+                    "group": "explorer-exclude@1",
+                    "when": "explorer-exclude.hasLoaded && !explorer-exclude.missingWorkspace && view == explorerExclude.pane.items && viewItem && viewItem != '**/.git' && viewItem != '**/.svn'&& viewItem != '**/.hg'&& viewItem != '**/CVS'&& viewItem != '**/.DS_Store' && viewItem != '**/Thumbs.db' && viewItem != '**/*.git'"
+                }
+            ],
+            "view/title": [
+                {
+                    "command": "explorer-exclude.disableAll",
+                    "group": "navigation@10",
+                    "when": "explorer-exclude.hasLoaded && !explorer-exclude.missingWorkspace && view == explorerExclude.pane.items"
+                },
+                {
+                    "command": "explorer-exclude.enableAll",
+                    "group": "navigation@11",
+                    "when": "explorer-exclude.hasLoaded && !explorer-exclude.missingWorkspace && view == explorerExclude.pane.items"
+                },
+                {
+                    "command": "explorer-exclude.toggleAllOn",
+                    "group": "navigation@12",
+                    "when": "explorer-exclude.hasLoaded && !explorer-exclude.missingWorkspace && view == explorerExclude.pane.items && !explorer-exclude.enabled"
+                },
+                {
+                    "command": "explorer-exclude.toggleAllOff",
+                    "group": "navigation@12",
+                    "when": "explorer-exclude.hasLoaded && !explorer-exclude.missingWorkspace && view == explorerExclude.pane.items && explorer-exclude.enabled"
+                },
+                {
+                    "command": "explorer-exclude.reset",
+                    "group": "navigation@13",
+                    "when": "explorer-exclude.hasLoaded && !explorer-exclude.missingWorkspace && view == explorerExclude.pane.items"
+                },
+                {
+                    "command": "explorer-exclude.openSettings",
+                    "group": "navigation@14",
+                    "when": "explorer-exclude.hasLoaded && !explorer-exclude.missingWorkspace && view == explorerExclude.pane.items"
+                }
+            ]
         }
-      ],
-      "view/item/context": [
-        {
-          "command": "explorer-exclude.remove",
-          "group": "explorer-exclude@1",
-          "when": "explorer-exclude.hasLoaded && !explorer-exclude.missingWorkspace && view == explorerExclude.pane.items && viewItem && viewItem != '**/.git' && viewItem != '**/.svn'&& viewItem != '**/.hg'&& viewItem != '**/CVS'&& viewItem != '**/.DS_Store' && viewItem != '**/Thumbs.db' && viewItem != '**/*.git'"
-        }
-      ],
-      "view/title": [
-        {
-          "command": "explorer-exclude.disableAll",
-          "group": "navigation@10",
-          "when": "explorer-exclude.hasLoaded && !explorer-exclude.missingWorkspace && view == explorerExclude.pane.items"
-        },
-        {
-          "command": "explorer-exclude.enableAll",
-          "group": "navigation@11",
-          "when": "explorer-exclude.hasLoaded && !explorer-exclude.missingWorkspace && view == explorerExclude.pane.items"
-        },
-        {
-          "command": "explorer-exclude.toggleAllOn",
-          "group": "navigation@12",
-          "when": "explorer-exclude.hasLoaded && !explorer-exclude.missingWorkspace && view == explorerExclude.pane.items && !explorer-exclude.enabled"
-        },
-        {
-          "command": "explorer-exclude.toggleAllOff",
-          "group": "navigation@12",
-          "when": "explorer-exclude.hasLoaded && !explorer-exclude.missingWorkspace && view == explorerExclude.pane.items && explorer-exclude.enabled"
-        },
-        {
-          "command": "explorer-exclude.reset",
-          "group": "navigation@13",
-          "when": "explorer-exclude.hasLoaded && !explorer-exclude.missingWorkspace && view == explorerExclude.pane.items"
-        },
-        {
-          "command": "explorer-exclude.openSettings",
-          "group": "navigation@14",
-          "when": "explorer-exclude.hasLoaded && !explorer-exclude.missingWorkspace && view == explorerExclude.pane.items"
-        }
-      ]
+    },
+    "scripts": {
+        "test": "npm run -s test:lint && npm run -s test:unit",
+        "test:unit": "echo 'No Unit Tests'",
+        "test:lint": "eslint --ext .js ./extension --fix && echo '\n【ツ】CODE PERFECTION !!!\n'"
+    },
+    "dependencies": {
+        "jsonc-parser": "^3.1.0",
+        "marked": "^4.0.18",
+        "vscode-nls-i18n": "^0.2.4"
+    },
+    "devDependencies": {
+        "babel-eslint": "^10.1.0",
+        "eslint": "^8.20.0",
+        "eslint-config-prettier": "^8.5.0",
+        "eslint-plugin-prettier": "^4.2.1",
+        "lint-staged": "^13.0.3",
+        "prettier": "^2.7.1"
     }
-  },
-  "scripts": {
-    "test": "npm run -s test:lint && npm run -s test:unit",
-    "test:unit": "echo 'No Unit Tests'",
-    "test:lint": "eslint --ext .js ./extension --fix && echo '\n【ツ】CODE PERFECTION !!!\n'"
-  },
-  "dependencies": {
-    "jsonc-parser": "^3.1.0",
-    "marked": "^4.0.18",
-    "vscode-nls-i18n": "^0.2.4"
-  },
-  "devDependencies": {
-    "babel-eslint": "^10.1.0",
-    "eslint": "^8.20.0",
-    "eslint-config-prettier": "^8.5.0",
-    "eslint-plugin-prettier": "^4.2.1",
-    "lint-staged": "^13.0.3",
-    "prettier": "^2.7.1"
-  }
 }

--- a/package.nls.json
+++ b/package.nls.json
@@ -12,6 +12,7 @@
     "extension.title": "Explorer Exclude",
     "package.disableAll": "Disable All",
     "package.enableAll": "Enable All",
+    "package.select": "Show Selected",
     "package.exclude": "Add to Hidden Items ...",
     "package.loading": "Loading Hidden Items ...",
     "package.pane": "Hidden Items",

--- a/package.nls.json
+++ b/package.nls.json
@@ -12,7 +12,7 @@
     "extension.title": "Explorer Exclude",
     "package.disableAll": "Disable All",
     "package.enableAll": "Enable All",
-    "package.select": "Show Selected",
+    "package.select": "Explorer Exclude: Show Selected",
     "package.exclude": "Add to Hidden Items ...",
     "package.loading": "Loading Hidden Items ...",
     "package.pane": "Hidden Items",


### PR DESCRIPTION
Overview
---

Add explorer-exclude.showSelected command that opens up QuickPick window with all the excluded items,
The user can select the relevant items that he wants to be visible, and then the command hides all the other items and makes the selected items visible.

Reviewer
---

Most of the relevant code is in the index.js file and util.js file.

Checklist
---

> I have tested each of the following, and they work as expected: ( required )

- [x] Meets [Contributing Guide](https://github.com/sfccdevops/explorer-exclude-vscode-extension/blob/develop/.github/CONTRIBUTING.md) Requirements
- [x] Pulled in the Latest Code from the `develop` branch
- [x] Works on a Desktop / Laptop Device


