### PR TITLE
Fix util.isNullOrUndefined is not a function

### DIFF
--- a/extension/util.js
+++ b/extension/util.js
@@ -2,7 +2,6 @@
 
 const fs = require('fs')
 const path = require('path')
-const util = require('util')
 const vscode = require('vscode')
 
 const { init, localize } = require('vscode-nls-i18n')
@@ -123,7 +122,7 @@ const ifExists = (_path) => {
   }
   return new Promise((res, rej) => {
     fs.access(_path, (error) => {
-      if (util.isNullOrUndefined(error)) {
+      if (error === null || error === undefined) {
         res(true)
       } else {
         rej(error)
@@ -137,7 +136,7 @@ const ifExists = (_path) => {
  * @param {string} _path
  */
 const isUnavailable = (_path) => {
-  return util.isNullOrUndefined(_path) || _path === ''
+  return _path === null || _path === undefined || _path === ''
 }
 
 /**


### PR DESCRIPTION
Overview
---
#66 
VS Code 1.128.1 uses Node.js 24.17.0, where `util.isNullOrUndefined()` has been removed (see https://nodejs.org/docs/latest-v24.x/api/deprecations.html#dep0051-utilisnullorundefined)

Applied the automated migration script

Reviewer
---

> Where should the reviewer start? How to Test? Background Context? etc ( required )

extension/util.js

Checklist
---

> I have tested each of the following, and they work as expected: ( required )

- [x] Meets [Contributing Guide](https://github.com/sfccdevops/explorer-exclude-vscode-extension/blob/develop/.github/CONTRIBUTING.md) Requirements
- [x] Pulled in the Latest Code from the `develop` branch
- [x] Works on a Desktop / Laptop Device
